### PR TITLE
Add "toOther" payment method

### DIFF
--- a/lib/asyncApi.js
+++ b/lib/asyncApi.js
@@ -340,7 +340,7 @@ module.exports = function Qiwi(token) {
 
     /**
      * Send to bank account
-     * @param {{ammount:number,account:string,account_type:number,exp_date:number}} requestOptions 
+     * @param {{amount:number,account:string,account_type:number,exp_date:number}} requestOptions 
      * @param {number} recipient 
      */
     this.toBank = function (requestOptions, recipient) {
@@ -362,6 +362,32 @@ module.exports = function Qiwi(token) {
                     account: requestOptions.account,
                     account_type: requestOptions.account_type,
                     exp_date: requestOptions.exp_date
+                }
+            }
+        };
+
+        return post(options);
+    }
+
+    /**
+     * Send to other service.
+     * @param {{providerId:string|number, amount:number, account:string}} requestOptions
+     */
+    this.toOther = function (requestOptions) {
+        var options = {
+            url: `${apiUri}/sinap/terms/${requestOptions.providerId}/payments`,
+            body: {
+                id: (1000 * Date.now()).toString(),
+                sum: {
+                    amount: requestOptions.amount,
+                    currency: "643"
+                },
+                paymentMethod: {
+                    type: "Account",
+                    accountId: "643"
+                },
+                fields: {
+                    account: requestOptions.account
                 }
             }
         };

--- a/lib/callbackApi.js
+++ b/lib/callbackApi.js
@@ -360,7 +360,7 @@ module.exports = function Qiwi(token) {
 
     /**
      * Send to bank account
-     * @param {{ammount:number,account:string,account_type:number,exp_date:number}} requestOptions 
+     * @param {{amount:number,account:string,account_type:number,exp_date:number}} requestOptions 
      * @param {number} recipient 
      * @param {function(err,data)} callback 
      */
@@ -389,6 +389,33 @@ module.exports = function Qiwi(token) {
 
         post(options, callback);
     }
+
+    /**
+     * Send to other service.
+     * @param {{providerId:string|number, amount:number, account:string}} requestOptions
+     * @param {function(err,data)} callback 
+     */
+    this.toOther = function (requestOptions, callback) {
+      var options = {
+          url: `${apiUri}/sinap/terms/${requestOptions.providerId}/payments`,
+          body: {
+              id: (1000 * Date.now()).toString(),
+              sum: {
+                  amount: requestOptions.amount,
+                  currency: "643"
+              },
+              paymentMethod: {
+                  type: "Account",
+                  accountId: "643"
+              },
+              fields: {
+                  account: requestOptions.account
+              }
+          }
+      };
+
+      post(options, callback);
+  }
 
     /**
     * Pay by requisites, only commercial receivers


### PR DESCRIPTION
I've added "toOther" payment method, that can help with making transfers to Yandex.Money, Steam etc.

Fixed spelling of "ammount" in asyncApi.js and callbackApi.js
